### PR TITLE
Hard-coding of US locale (namespaces)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 OpenADK (C# version)
 ====================
 
+Download and installation
+-------------------------
+
+To download the OpenADK code, simply click on the 'ZIP' button and uncompress to a directory. Once done, load the appropriate Solution under the `src` directory in Visual Studio.
+
+The code base should include the latest data models for each locale.
+
 Instructions for generating data model files
 --------------------------------------------
 
@@ -103,7 +110,7 @@ The [Using Pull Requests][2] article provides a comprehensive guide for issuing 
 
 10. Browse to your remote (forked) repository on the GitHub site.
 
-11. Swith to the *ISSUE_XXX* branch and press the "Pull Request" button.
+11. Switch to the *ISSUE_XXX* branch and press the "Pull Request" button.
 
 12. Review the Pull Request details and provide a meaningful title (with issue number if appropriate) and description of your change. It is important to ensure that the _base branch_ is set to _develop_ and the _head branch_ is set to *ISSUE_XXX*.
 

--- a/src/core/OpenADK-NET-Core.csproj
+++ b/src/core/OpenADK-NET-Core.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="3.5">
   <PropertyGroup>
     <ProjectType>Local</ProjectType>
@@ -139,7 +139,9 @@
     <Reference Include="System.Configuration" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="OpenADK\IntrinsicLibraryType.cs" />
     <Compile Include="OpenADK\ISifDtd.cs" />
+    <Compile Include="OpenADK\SifDtd.cs" />
     <Compile Include="Properties\AssemblyInfo.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/src/core/OpenADK/Adk.cs
+++ b/src/core/OpenADK/Adk.cs
@@ -77,6 +77,16 @@ namespace OpenADK.Library
             Initialize(SifVersion.LATEST, SIFVariant.SIF_US, int.MaxValue);
         }
 
+        /// <summary>
+        /// Initialize the Adk to use the latest version of SIF and all SIF Data Object (Sdo) libraries for the
+        /// specified variant. Calling this method when the Adk has already been initialized has no effect.
+        /// </summary>
+        /// <param name="sifVariant">SIF variant (locale) used.</param>
+        public static void Initialize(SIFVariant sifVariant)
+        {
+            Initialize(SifVersion.LATEST, sifVariant, int.MaxValue);
+        }
+
         /// <summary>  Initialize the Adk to use the specified version of SIF.
         /// 
         /// Calling this method when the Adk has already been initialized has no effect.
@@ -171,7 +181,7 @@ namespace OpenADK.Library
 
             // the default formatter for String APIs in the ADK is the SIF 1.x formatter
             // for backwards compatibility
-            sSingleton.fDefaultFormatter = OpenADK.Library.us.SifDtd.SIF_1X_FORMATTER;//Todo: SifDtd should have base class and move non-language related material out
+            sSingleton.fDefaultFormatter = SifDtd.SIF_1X_FORMATTER;
 
             //
             //	Set up the ServerLog

--- a/src/core/OpenADK/Agent.cs
+++ b/src/core/OpenADK/Agent.cs
@@ -12,7 +12,6 @@ using System.Runtime.CompilerServices;
 using OpenADK.Library.Impl;
 using OpenADK.Library.Log;
 using log4net;
-using OpenADK.Library.us;
 
 namespace OpenADK.Library
 {

--- a/src/core/OpenADK/Global/GlobalDTD.cs
+++ b/src/core/OpenADK/Global/GlobalDTD.cs
@@ -12,7 +12,6 @@ using System.Runtime.CompilerServices;
 using OpenADK.Util;
 using OpenADK.Library;
 using OpenADK.Library.Impl;
-using SifDtd = OpenADK.Library.us.SifDtd;
 
 namespace OpenADK.Library.Global
 {

--- a/src/core/OpenADK/Impl/DTDInternals.cs
+++ b/src/core/OpenADK/Impl/DTDInternals.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Text;
 using System.Runtime.CompilerServices;
 using OpenADK.Library.Global;
-using OpenADK.Library.us;
 using OpenADK.Util;
 
 /**
@@ -84,16 +83,12 @@ namespace OpenADK.Library.Impl
                 }
             }
 
-            // TODO: Common should be loaded as an "Intrinsic Library in the SDO DTD"
-            // Note: This works by... luck I guess.  This will load the SdoLibraryType.Common for the US.  However,
-            //      the code generator generates every locale's common library as the same number.  So this should work for all locales.
-            //      If the Adk makes it to 3.0, this should be rectified however.
-            LoadLibrary((int)SdoLibraryType.Common, sdoAssembly);
+            LoadLibrary((int)IntrinsicLibraryType.Common, sdoAssembly);
  
             //Remove the libraries that have already been loaded.
             int toLoad = libraries & ~IntrinsicLibraries;
 
-            toLoad = toLoad & ~(int) SdoLibraryType.Common;
+            toLoad = toLoad & ~(int) IntrinsicLibraryType.Common;
 
             foreach (int lib in GetSdoTypes(toLoad))
             {
@@ -114,7 +109,7 @@ namespace OpenADK.Library.Impl
         { 
             get
             {
-                return (int)(SdoLibraryType.Global | SdoLibraryType.Infra );
+                return (int)(IntrinsicLibraryType.Global | IntrinsicLibraryType.Infra );
             }
         }
 

--- a/src/core/OpenADK/Impl/ElementDefImpl.cs
+++ b/src/core/OpenADK/Impl/ElementDefImpl.cs
@@ -9,7 +9,6 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using OpenADK.Library.Impl.Surrogates;
-using OpenADK.Library.us;
 
 namespace OpenADK.Library.Impl
 {

--- a/src/core/OpenADK/Impl/ProvisioningMatrix.cs
+++ b/src/core/OpenADK/Impl/ProvisioningMatrix.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using OpenADK.Library.us;
 
 namespace OpenADK.Library.Impl
 {

--- a/src/core/OpenADK/Impl/SIF_Message.cs
+++ b/src/core/OpenADK/Impl/SIF_Message.cs
@@ -21,7 +21,7 @@ namespace OpenADK.Library.Impl
     internal class SIF_Message : SifMessagePayload
     {
         public SIF_Message()
-            : base(OpenADK.Library.us.SifDtd.SIF_MESSAGE) { }//Todo: SifDtd should have base class and move non-language related material out
+            : base(SifDtd.SIF_MESSAGE) { }
 
         /// <summary>  Gets the value of the <c>Version</c> attribute.
         /// The SIF specification defines the meaning of this attribute as: "The version of SIF to which this message conforms"
@@ -33,9 +33,9 @@ namespace OpenADK.Library.Impl
         /// </version>
         public virtual String Version
         {
-            get { return GetFieldValue(OpenADK.Library.us.SifDtd.SIF_MESSAGE_VERSION); }//Todo: SifDtd should have base class and move non-language related material out
+            get { return GetFieldValue(SifDtd.SIF_MESSAGE_VERSION); }
 
-            set { SetField(OpenADK.Library.us.SifDtd.SIF_MESSAGE_VERSION, value); }//Todo: SifDtd should have base class and move non-language related material out
+            set { SetField(SifDtd.SIF_MESSAGE_VERSION, value); }
         }
     }
 }

--- a/src/core/OpenADK/Infra/InfraDTD.cs
+++ b/src/core/OpenADK/Infra/InfraDTD.cs
@@ -12,7 +12,6 @@ using System.Runtime.CompilerServices;
 using OpenADK.Util;
 using OpenADK.Library;
 using OpenADK.Library.Impl;
-using SifDtd = OpenADK.Library.us.SifDtd;
 
 namespace OpenADK.Library.Infra
 {

--- a/src/core/OpenADK/IntrinsicLibraryType.cs
+++ b/src/core/OpenADK/IntrinsicLibraryType.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace OpenADK.Library
+{
+
+    /// <summary>
+    /// Values identifying each package that is considered to be an intrinsic library.
+    /// </summary>
+    [Flags]
+    public enum IntrinsicLibraryType : int
+    {
+        /// <summary> All SDO libraries </summary>
+        All = -1, // 0xFFFFFFFF
+
+        /// <summary> No SDO libraries </summary>
+        None = 0x00000000,
+
+        //  These are always loaded regardless of what the user specifies.
+        //  They are considered "built-in" SDO libraries but under the hood they're
+        //  treated just like any other SDO package.
+        /// <summary>Identifies the Infrastructure Sdo library</summary>
+        Global = 0x40000000,
+
+        /// <summary>Identifies the Infrastructure Sdo library</summary>
+        Infra = 0x20000000,
+
+        /// <summary>Identifies the Infrastructure Sdo library</summary>
+        Common = 0x10000000
+    }
+
+}

--- a/src/core/OpenADK/SIFDate.cs
+++ b/src/core/OpenADK/SIFDate.cs
@@ -64,10 +64,10 @@ namespace OpenADK.Library
                                                     SifVersion version )
         {
             if ( version.CompareTo( SifVersion.SIF20 ) >= 0 ) {
-                return OpenADK.Library.us.SifDtd.SIF_2X_FORMATTER.ToDate( sifDate ); //Todo: SifDtd should have base class and move non-language related material out
+                return SifDtd.SIF_2X_FORMATTER.ToDate( sifDate );
             }
             else {
-                return OpenADK.Library.us.SifDtd.SIF_1X_FORMATTER.ToDate(sifDate);//Todo: SifDtd should have base class and move non-language related material out
+                return SifDtd.SIF_1X_FORMATTER.ToDate(sifDate);
             }
         }
     }

--- a/src/core/OpenADK/SifDtd.cs
+++ b/src/core/OpenADK/SifDtd.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using OpenADK.Util;
+using OpenADK.Library;
+using OpenADK.Library.Impl;
+
+namespace OpenADK.Library
+{
+
+    /// <summary>Metadata for the Schools Interoperability Framework (SIF)</summary>
+    /// <remarks>
+    /// <para>
+    /// SIFDTD defines global {@linkplain com.edustructures.sifworks.ElementDef}
+    /// constants that describe SIF Data Objects, elements, and attributes across all
+    /// supported versions of the SIF Specification. The ADK uses this metadata
+    /// internally to parse and render SIF Data Objects.  In addition, many of the
+    /// framework APIs require that the programmer pass an ElementDef constant from
+    /// the SIFDTD class to identify an object, element, or attribute.
+    /// </para>
+    /// <para>
+    /// ElementDef constants are named <c>[PARENT_]ENTITY</c>, where
+    /// <c>PARENT</c> is the name of the parent element and
+    /// <c>ENTITY</c> is the name of the element or attribute
+    /// encapsulated by the ElementDef. Some examples of ElementDef constants defined
+    /// by this class include:
+    /// </para>
+    /// <list type="table">
+    /// <listheader><term>IElementDef</term><description>Description</description></listheader>
+    /// <item><term><c>SIFDTD.STUDENTPERSONAL</c></term><description>Identifies the StudentPersonal data object</description></item>
+    /// <item><term><c>SIFDTD.SCHOOLINFO</c></term><description>Identifies the SchoolInfo data object</description></item>
+    /// </list>
+    /// Many of the Adk's public interfaces require an ElementDef constant to be passed
+    /// as a parameter. For example, the first parameter to the <see cref="IZone.SetSubscriber"/>
+    /// method is an IElementDef:
+    /// <code>myZone.setSubscriber( SIFDTD.BUSINFO, this, ADKFlags.PROV_SUBSCRIBE );</code>
+    /// ElementDef also identifies child elements and attributes as demonstrated by the <c>Query.AddCondition</c> method:
+    /// <code>
+    /// Query query = new Query( SifDtd.STUDENTPERSONAL );
+    /// query.AddCondition( SifDtd.STUDENTPERSONAL_REFID, Condition.EQ, "4A37969803F0D00322AF0EB969038483" );
+    /// </code>
+    /// <para>
+    /// <b>SDO Libraries</b>
+    /// </para>
+    /// <para>
+    /// ElementDef metadata is grouped into "SDO Libraries", which are organized along
+    /// SIF Working Group boundaries. SDO Libraries are loaded into the <c>SifDtd</c>
+    /// class when the Adk is initialized. All or part of the metadata is loaded into depending on the flags passed to the
+    /// <see cref="Adk.Initialize(SifVersion, SdoLibraryType)"/> method,
+    /// metadata from one or more SDO Libraries may be loaded. For example, the following
+    /// call loads metadata for the <c>Student Information Working Group Objects</c>
+    /// and <c>Transportation And Geographic Information Working Group Objects</c>
+    /// (Common Elements and <c>Infrastructure Working Group Objects</c> metadata is always loaded
+    /// </para>
+    /// <code>Adk.Initialize( SiFVersion.LATEST, SdoLibraryType.Student | SdoLibraryType.Trans )</code>
+    /// <para>
+    /// If an given SDO Library is not loaded, all of the SIFDTD constants that belong
+    /// to that library will be <code>null</code> and cannot be referenced. For example,
+    /// given the SDO Libraries loaded above, attempting to reference the
+    /// <code>SIFDTD.LIBRARYPATRONSTATUS</code> object from the Library Automation Working
+    /// Group would result in a NullPointerException:
+    /// </para>
+    /// <code>SifDtd.LIBRARYPATRONSTATUS.Name;</code>
+    /// </remarks>
+    public abstract class SifDtd : DTDInternals, ISifDtd
+    {
+
+        // Declare core object and field elements defined by all versions of SIF
+        // supported by the class framework.
+
+        // Package names that comprise the SIF Data Objects library
+        public const string COMMON = "Common";
+        public const string DATAMODEL = "Datamodel";
+        public const string GLOBAL = "Global";
+        public const string INFRA = "Infra";
+
+        // The name of the data model variant this class is defined in
+        public virtual string Variant
+        {
+            get { return null; }
+        }
+
+        public virtual List<string> LoadedLibraryNames
+        {
+            get { return null; }
+        }
+
+        /** The base xmlns for this edition of the ADK without the version */
+        public virtual string XMLNS_BASE
+        {
+            get
+            {
+                return "http://www.sifinfo.org/" + ("us".Equals(Variant) ? "/" : Variant + "/") + "infrastructure";
+            }
+        }
+
+        /**
+         *  Returns the package name for all classes in this data model
+         */
+        public override String BasePackageName {
+            get
+            {
+                return "OpenADK.Library." + Variant;
+            }
+        }
+
+        /**
+         *  Returns the base version-independent namespace for this data model variant
+         */
+        public override String BaseNamespace {
+            get
+            {
+                if ( "us".Equals( Variant ))
+                    return "http://www.sifinfo.org/infrastructure";
+                else
+                    return "http://www.sifinfo.org/" + Variant + "/infrastructure";
+            }
+        }
+
+        /// <summary>  Gets the names of all Sdo libraries offered with this version of the Adk (Excluding Common, DataModel, and Infra)</summary>
+        public virtual int[] AvailableLibraries
+        {
+            get { return null; }
+        }
+
+        public override string SDOAssembly
+        {
+            // TODO: This will use reflection in the future
+            get { return "OpenADK.SDO-" + Variant.ToUpper(); }
+        }
+
+    }
+
+}

--- a/src/core/OpenADK/au/SdoLibraryType.cs
+++ b/src/core/OpenADK/au/SdoLibraryType.cs
@@ -16,22 +16,22 @@ namespace OpenADK.Library.au
 	public enum SdoLibraryType : int
 {
 	/// <summary> All SDO libraries </summary>
-	All = -1, // 0xFFFFFFFF
+	All = IntrinsicLibraryType.All,
 
 	/// <summary> No SDO libraries </summary>
-	None = 0x00000000,
+	None = IntrinsicLibraryType.None,
 
 	//  These are always loaded regardless of what the user specifies.
 	//  They are considered "built-in" SDO libraries but under the hood they're 
 	//  treated just like any other SDO package.
 	/// <summary>Identifies the Infrastructure Sdo library</summary>
-	Global = 0x40000000,
+	Global = IntrinsicLibraryType.Global,
 
 	/// <summary>Identifies the Infrastructure Sdo library</summary>
-	Infra = 0x20000000,
+	Infra = IntrinsicLibraryType.Infra,
 
 	/// <summary>Identifies the Infrastructure Sdo library</summary>
-	Common = 0x10000000,
+	Common = IntrinsicLibraryType.Common,
 
 	/// <summary>Identifies the null Sdo library</summary>
 	Dw = 0x000001,

--- a/src/core/OpenADK/au/SifDtd.cs
+++ b/src/core/OpenADK/au/SifDtd.cs
@@ -73,12 +73,8 @@ using System.Text;
 	/// </para>
 	/// <code>SifDtd.LIBRARYPATRONSTATUS.Name;</code>
 	/// </remarks>
-public sealed partial class SifDtd : DTDInternals, ISifDtd
+public sealed partial class SifDtd : OpenADK.Library.SifDtd
 {
-	// SIF_Message mapping used internally by SIFParser
-	public static IElementDef SIF_MESSAGE = new ElementDefImpl(null,"SIF_Message",null,0,"Impl",SifVersion.SIF11, SifVersion.LATEST );
-	public static IElementDef SIF_MESSAGE_VERSION = new ElementDefImpl( SifDtd.SIF_MESSAGE,"Version",null,1,SifDtd.INFRA,(byte)(ElementDefImpl.FD_FIELD),SifVersion.SIF11, SifVersion.LATEST );
-
 	// Declare all object and field elements defined by all versions of SIF
 	// supported by the class framework.
 
@@ -87,8 +83,6 @@ public sealed partial class SifDtd : DTDInternals, ISifDtd
 	public const string DW = "Dw";
 	/** The name of the null package */
 	public const string SYSTEM = "System";
-	/** The name of the  package */
-	public const string GLOBAL = "Global";
 	/** The name of the null package */
 	public const string ASSESSMENT = "Assessment";
 	/** The name of the null package */
@@ -97,28 +91,22 @@ public sealed partial class SifDtd : DTDInternals, ISifDtd
 	public const string SCHOOL = "School";
 	/** The name of the null package */
 	public const string STUDENT = "Student";
-	/** The name of the Core Infrastructure package */
-	public const string INFRA = "Infra";
 	/** The name of the null package */
 	public const string LEARNING = "Learning";
 	/** The name of the null package */
-	public const string COMMON = "Common";
-	/** The name of the null package */
 	public const string REPORTING = "Reporting";
-	/** The name of the null package */
-	public const string DATAMODEL = "Datamodel";
 	/** The name of the null package */
 	public const string GRADEBOOK = "Gradebook";
 	/** The name of the Infrastructure package */
 	public const string INFRASTRUCTURE = "Infrastructure";
 
 	// The name of the data model variant this class is defined in
-	public string Variant { 
+	public override string Variant { 
 		get{
 			return "au";
 		}
 	}
-	public List<string> LoadedLibraryNames
+	public override List<string> LoadedLibraryNames
 	{
 	get
 			{
@@ -139,7 +127,7 @@ public sealed partial class SifDtd : DTDInternals, ISifDtd
 	}
 
 	/** The base xmlns for this edition of the ADK without the version */
-	public string XMLNS_BASE {
+	public override string XMLNS_BASE {
 		get{
 			return "http://www.sifinfo.org/au/infrastructure";
 		}
@@ -156,30 +144,6 @@ public sealed partial class SifDtd : DTDInternals, ISifDtd
 
 // BEGIN EXTRA METHODS (SIFDTD_Template_CS.txt)
 
-	/**
-	 *  Returns the package name for all classes in this data model
-	 */
-	public override String BasePackageName {
-        get
-        {
-		    return "OpenADK.Library." + Variant;
-        }
-	}
-
-
-
-	/**
-	 *  Returns the base version-independent namespace for this data model variant
-	 */
-	public override String BaseNamespace {
-        get
-        {
-        	if ( "us".Equals( Variant ))
-	            return "http://www.sifinfo.org/infrastructure";
-	        else
-	        	return "http://www.sifinfo.org/" + Variant + "/infrastructure";
-        }
-	}
 
     protected override String GetLibraryName(int type)
     {
@@ -189,7 +153,7 @@ public sealed partial class SifDtd : DTDInternals, ISifDtd
 
 
     /// <summary>  Gets the names of all Sdo libraries offered with this version of the Adk (Excluding Common, DataModel, and Infra)</summary>
-    public int[] AvailableLibraries
+    public override int[] AvailableLibraries
     {
         //TODO: Look at this signature to see if it can be changed back to SDOLibraryType
         get { return GetSdoTypes( (int)SdoLibraryType.All ^ (IntrinsicLibraries)).ToArray(); }
@@ -227,13 +191,6 @@ public sealed partial class SifDtd : DTDInternals, ISifDtd
         }
         return libTypes;
 
-    }
-
-
-    public override string SDOAssembly
-    {
-        // TODO: This will use reflection in the future
-        get { return "OpenADK.SDO-" + Variant.ToUpper(); }
     }
 
 // END EXTRA METHODS

--- a/src/core/OpenADK/uk/SdoLibraryType.cs
+++ b/src/core/OpenADK/uk/SdoLibraryType.cs
@@ -16,22 +16,22 @@ namespace OpenADK.Library.uk
 	public enum SdoLibraryType : int
 {
 	/// <summary> All SDO libraries </summary>
-	All = -1, // 0xFFFFFFFF
+	All = IntrinsicLibraryType.All,
 
 	/// <summary> No SDO libraries </summary>
-	None = 0x00000000,
+	None = IntrinsicLibraryType.None,
 
 	//  These are always loaded regardless of what the user specifies.
 	//  They are considered "built-in" SDO libraries but under the hood they're 
 	//  treated just like any other SDO package.
 	/// <summary>Identifies the Infrastructure Sdo library</summary>
-	Global = 0x40000000,
+	Global = IntrinsicLibraryType.Global,
 
 	/// <summary>Identifies the Infrastructure Sdo library</summary>
-	Infra = 0x20000000,
+	Infra = IntrinsicLibraryType.Infra,
 
 	/// <summary>Identifies the Infrastructure Sdo library</summary>
-	Common = 0x10000000,
+	Common = IntrinsicLibraryType.Common,
 
 	/// <summary>Identifies the Catering Sdo library</summary>
 	Catering = 0x000001,

--- a/src/core/OpenADK/uk/SifDtd.cs
+++ b/src/core/OpenADK/uk/SifDtd.cs
@@ -73,20 +73,14 @@ using System.Text;
 	/// </para>
 	/// <code>SifDtd.LIBRARYPATRONSTATUS.Name;</code>
 	/// </remarks>
-public sealed partial class SifDtd : DTDInternals, ISifDtd
+public sealed partial class SifDtd : OpenADK.Library.SifDtd
 {
-	// SIF_Message mapping used internally by SIFParser
-	public static IElementDef SIF_MESSAGE = new ElementDefImpl(null,"SIF_Message",null,0,"Impl",SifVersion.SIF11, SifVersion.LATEST );
-	public static IElementDef SIF_MESSAGE_VERSION = new ElementDefImpl( SifDtd.SIF_MESSAGE,"Version",null,1,SifDtd.INFRA,(byte)(ElementDefImpl.FD_FIELD),SifVersion.SIF11, SifVersion.LATEST );
-
 	// Declare all object and field elements defined by all versions of SIF
 	// supported by the class framework.
 
 	// Package names that comprise the SIF Data Objects library
 	/** The name of the Catering package */
 	public const string CATERING = "Catering";
-	/** The name of the  package */
-	public const string GLOBAL = "Global";
 	/** The name of the null package */
 	public const string ASSESSMENT = "Assessment";
 	/** The name of the null package */
@@ -95,26 +89,20 @@ public sealed partial class SifDtd : DTDInternals, ISifDtd
 	public const string SCHOOL = "School";
 	/** The name of the null package */
 	public const string LEARNER = "Learner";
-	/** The name of the Core Infrastructure package */
-	public const string INFRA = "Infra";
 	/** The name of the Learning package */
 	public const string LEARNING = "Learning";
 	/** The name of the null package */
-	public const string COMMON = "Common";
-	/** The name of the null package */
 	public const string REPORTING = "Reporting";
-	/** The name of the Data Model package */
-	public const string DATAMODEL = "Datamodel";
 	/** The name of the Infrastructure package */
 	public const string INFRASTRUCTURE = "Infrastructure";
 
 	// The name of the data model variant this class is defined in
-	public string Variant { 
+	public override string Variant { 
 		get{
 			return "uk";
 		}
 	}
-	public List<string> LoadedLibraryNames
+	public override List<string> LoadedLibraryNames
 	{
 	get
 			{
@@ -135,7 +123,7 @@ public sealed partial class SifDtd : DTDInternals, ISifDtd
 	}
 
 	/** The base xmlns for this edition of the ADK without the version */
-	public string XMLNS_BASE {
+	public override string XMLNS_BASE {
 		get{
 			return "http://www.sifinfo.org/uk/infrastructure";
 		}
@@ -152,30 +140,6 @@ public sealed partial class SifDtd : DTDInternals, ISifDtd
 
 // BEGIN EXTRA METHODS (SIFDTD_Template_CS.txt)
 
-	/**
-	 *  Returns the package name for all classes in this data model
-	 */
-	public override String BasePackageName {
-        get
-        {
-		    return "OpenADK.Library." + Variant;
-        }
-	}
-
-
-
-	/**
-	 *  Returns the base version-independent namespace for this data model variant
-	 */
-	public override String BaseNamespace {
-        get
-        {
-        	if ( "us".Equals( Variant ))
-	            return "http://www.sifinfo.org/infrastructure";
-	        else
-	        	return "http://www.sifinfo.org/" + Variant + "/infrastructure";
-        }
-	}
 
     protected override String GetLibraryName(int type)
     {
@@ -185,7 +149,7 @@ public sealed partial class SifDtd : DTDInternals, ISifDtd
 
 
     /// <summary>  Gets the names of all Sdo libraries offered with this version of the Adk (Excluding Common, DataModel, and Infra)</summary>
-    public int[] AvailableLibraries
+    public override int[] AvailableLibraries
     {
         //TODO: Look at this signature to see if it can be changed back to SDOLibraryType
         get { return GetSdoTypes( (int)SdoLibraryType.All ^ (IntrinsicLibraries)).ToArray(); }
@@ -223,13 +187,6 @@ public sealed partial class SifDtd : DTDInternals, ISifDtd
         }
         return libTypes;
 
-    }
-
-
-    public override string SDOAssembly
-    {
-        // TODO: This will use reflection in the future
-        get { return "OpenADK.SDO-" + Variant.ToUpper(); }
     }
 
 // END EXTRA METHODS

--- a/src/core/OpenADK/us/SdoLibraryType.cs
+++ b/src/core/OpenADK/us/SdoLibraryType.cs
@@ -16,22 +16,22 @@ namespace OpenADK.Library.us
 	public enum SdoLibraryType : int
 {
 	/// <summary> All SDO libraries </summary>
-	All = -1, // 0xFFFFFFFF
+	All = IntrinsicLibraryType.All,
 
 	/// <summary> No SDO libraries </summary>
-	None = 0x00000000,
+	None = IntrinsicLibraryType.None,
 
 	//  These are always loaded regardless of what the user specifies.
 	//  They are considered "built-in" SDO libraries but under the hood they're 
 	//  treated just like any other SDO package.
 	/// <summary>Identifies the Infrastructure Sdo library</summary>
-	Global = 0x40000000,
+	Global = IntrinsicLibraryType.Global,
 
 	/// <summary>Identifies the Infrastructure Sdo library</summary>
-	Infra = 0x20000000,
+	Infra = IntrinsicLibraryType.Infra,
 
 	/// <summary>Identifies the Infrastructure Sdo library</summary>
-	Common = 0x10000000,
+	Common = IntrinsicLibraryType.Common,
 
 	/// <summary>Identifies the null Sdo library</summary>
 	Programs = 0x000001,

--- a/src/core/OpenADK/us/SifDtd.cs
+++ b/src/core/OpenADK/us/SifDtd.cs
@@ -73,12 +73,8 @@ using System.Text;
 	/// </para>
 	/// <code>SifDtd.LIBRARYPATRONSTATUS.Name;</code>
 	/// </remarks>
-public sealed partial class SifDtd : DTDInternals, ISifDtd
+public sealed partial class SifDtd : OpenADK.Library.SifDtd
 {
-	// SIF_Message mapping used internally by SIFParser
-	public static IElementDef SIF_MESSAGE = new ElementDefImpl(null,"SIF_Message",null,0,"Impl",SifVersion.SIF11, SifVersion.LATEST );
-	public static IElementDef SIF_MESSAGE_VERSION = new ElementDefImpl( SifDtd.SIF_MESSAGE,"Version",null,1,SifDtd.INFRA,(byte)(ElementDefImpl.FD_FIELD),SifVersion.SIF11, SifVersion.LATEST );
-
 	// Declare all object and field elements defined by all versions of SIF
 	// supported by the class framework.
 
@@ -91,24 +87,16 @@ public sealed partial class SifDtd : DTDInternals, ISifDtd
 	public const string TRANS = "Trans";
 	/** The name of the null package */
 	public const string FOOD = "Food";
-	/** The name of the Core Infrastructure package */
-	public const string INFRA = "Infra";
 	/** The name of the null package */
 	public const string ETRANSCRIPTS = "Etranscripts";
 	/** The name of the null package */
 	public const string DW = "Dw";
-	/** The name of the null package */
-	public const string COMMON = "Common";
-	/** The name of the null package */
-	public const string DATAMODEL = "Datamodel";
 	/** The name of the null package */
 	public const string ASSESSMENT = "Assessment";
 	/** The name of the null package */
 	public const string PROFDEV = "Profdev";
 	/** The name of the null package */
 	public const string LIBRARY = "Library";
-	/** The name of the  package */
-	public const string GLOBAL = "Global";
 	/** The name of the null package */
 	public const string GRADEBOOK = "Gradebook";
 	/** The name of the null package */
@@ -121,12 +109,12 @@ public sealed partial class SifDtd : DTDInternals, ISifDtd
 	public const string HRFIN = "Hrfin";
 
 	// The name of the data model variant this class is defined in
-	public string Variant { 
+	public override string Variant { 
 		get{
 			return "us";
 		}
 	}
-	public List<string> LoadedLibraryNames
+	public override List<string> LoadedLibraryNames
 	{
 	get
 			{
@@ -147,7 +135,7 @@ public sealed partial class SifDtd : DTDInternals, ISifDtd
 	}
 
 	/** The base xmlns for this edition of the ADK without the version */
-	public string XMLNS_BASE {
+	public override string XMLNS_BASE {
 		get{
 			return "http://www.sifinfo.org/infrastructure";
 		}
@@ -164,30 +152,6 @@ public sealed partial class SifDtd : DTDInternals, ISifDtd
 
 // BEGIN EXTRA METHODS (SIFDTD_Template_CS.txt)
 
-	/**
-	 *  Returns the package name for all classes in this data model
-	 */
-	public override String BasePackageName {
-        get
-        {
-		    return "OpenADK.Library." + Variant;
-        }
-	}
-
-
-
-	/**
-	 *  Returns the base version-independent namespace for this data model variant
-	 */
-	public override String BaseNamespace {
-        get
-        {
-        	if ( "us".Equals( Variant ))
-	            return "http://www.sifinfo.org/infrastructure";
-	        else
-	        	return "http://www.sifinfo.org/" + Variant + "/infrastructure";
-        }
-	}
 
     protected override String GetLibraryName(int type)
     {
@@ -197,7 +161,7 @@ public sealed partial class SifDtd : DTDInternals, ISifDtd
 
 
     /// <summary>  Gets the names of all Sdo libraries offered with this version of the Adk (Excluding Common, DataModel, and Infra)</summary>
-    public int[] AvailableLibraries
+    public override int[] AvailableLibraries
     {
         //TODO: Look at this signature to see if it can be changed back to SDOLibraryType
         get { return GetSdoTypes( (int)SdoLibraryType.All ^ (IntrinsicLibraries)).ToArray(); }
@@ -235,13 +199,6 @@ public sealed partial class SifDtd : DTDInternals, ISifDtd
         }
         return libTypes;
 
-    }
-
-
-    public override string SDOAssembly
-    {
-        // TODO: This will use reflection in the future
-        get { return "OpenADK.SDO-" + Variant.ToUpper(); }
     }
 
 // END EXTRA METHODS


### PR DESCRIPTION
Fixed an issue whereby the US namespace was being hard-coded within CORE classes. Created "global" versions of the SifDtd and SdoLibraryType classes that could be referenced instead and put locale-independent functions in them. Removed direct reference to the US namespace in CORE classes.
